### PR TITLE
Add prefixing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ extern crate clap;
 extern crate stellar_vanity;
 
 use clap::{App, Arg};
+use stellar_vanity::vanity_key::AddressGenerator;
 
 fn main() {
     let matches = App::new("Stellar Vanity Address Generator")
@@ -10,18 +11,46 @@ fn main() {
         .about("A simple CLI for generating Stellar Vanity Addresses.")
         .arg(
             Arg::with_name("POSTFIX")
-                .required(true)
+                .long("postfix")
                 .takes_value(true)
-                .index(1)
-                .help("desired address postfix"),
+                .help("desired address suffix"),
+        )
+        .arg(
+            Arg::with_name("PREFIX")
+                .long("prefix")
+                .takes_value(true)
+                .help("desired address prefix"),
         )
         .get_matches();
-    let postfix = matches.value_of("POSTFIX").unwrap();
+
+    let postfix_option = matches.value_of("POSTFIX");
+    let prefix_option = matches.value_of("PREFIX");
+
+    if postfix_option.is_none() && prefix_option.is_none() {
+        eprintln!("\n Please, provide prefix or postfix");
+        ::std::process::exit(1);
+    }
+
+    let mut generator: AddressGenerator = Default::default();
 
     println!("\nSEARCHING INITIATED");
 
-    let (public_key, private_key) =
-        stellar_vanity::vanity_key::generate_vanity_key(&postfix.to_uppercase());
+    let (public_key, private_key) = generator
+        .find(|(pk, _)| {
+            let mut found = true;
+            let key_str = pk.as_str();
+
+            if let Some(postfix) = postfix_option {
+                found &= key_str.ends_with(postfix);
+            }
+
+            if let Some(prefix) = prefix_option {
+                found &= key_str[2..].starts_with(prefix);
+            }
+
+            found
+        })
+        .unwrap();
 
     println!(
         "\nSUCCESS!\nPublic Key: {:?}\nSecret Key: {:?}",

--- a/src/vanity_key/mod.rs
+++ b/src/vanity_key/mod.rs
@@ -1,80 +1,77 @@
-use rand::{Rng, CryptoRng};
-use rand::rngs::OsRng;
-use ed25519_dalek::Keypair;
 use base32::encode;
 use base32::Alphabet::RFC4648;
-use crc16::*;
-use byteorder::LittleEndian;
 use bytes::{BufMut, BytesMut};
+use crc16::*;
+use ed25519_dalek::Keypair;
+use rand::rngs::OsRng;
+use rand::{CryptoRng, Rng};
 
-fn generate_random_key<A>(rng: &mut A) -> (String, String)
-    where A: Rng + CryptoRng
+pub struct AddressGenerator<T = OsRng>
+where
+    T: Rng + CryptoRng,
 {
-    // Generate ED25519 key pair
-    let keypair: Keypair = Keypair::generate(rng);
-
-    // ************** Encode the public key ***************** //
-    const VERSION_BYTE_ACCOUNT_ID: u8 = 6 << 3;
-    let mut bytes_public = vec![VERSION_BYTE_ACCOUNT_ID];
-    // Combine the byte version and the ED25519 raw public key bytes array
-    &bytes_public.extend_from_slice(&keypair.public.to_bytes());
-    // Calculate checksum
-    let checksum_public = State::<XMODEM>::calculate(&bytes_public);
-    // Create a buffer to combine byte version : ED25519 raw key : checksum
-    let mut bytes_buffer_public = BytesMut::with_capacity(1024);
-    bytes_buffer_public.put(&bytes_public);
-    bytes_buffer_public.put_u16::<LittleEndian>(checksum_public);
-    // Base 32 encode the public key
-    let public_key = encode(RFC4648 { padding: false }, &bytes_buffer_public);
-
-    // ************** Encode the private key ***************** //
-    const VERSION_BYTE_SEED: u8 = 18 << 3;
-    let mut bytes_private = vec![VERSION_BYTE_SEED];
-    // Combine the byte version and the ED25519 raw private key bytes array
-    &bytes_private.extend_from_slice(&keypair.secret.to_bytes());
-    // Calculate checksum
-    let check_sum_private = State::<XMODEM>::calculate(&bytes_private);
-    // Create a buffer to combine byte version : ED25519 raw key : checksum
-    let mut bytes_buffer_private = BytesMut::with_capacity(1024);
-    bytes_buffer_private.put(&bytes_private);
-    bytes_buffer_private.put_u16::<LittleEndian>(check_sum_private);
-    // Base 32 encode the private key
-    let private_key = encode(RFC4648 { padding: false }, &bytes_buffer_private);
-
-    (public_key, private_key)
+    rng: T,
 }
 
-/// Stellar vanity wallet generator.
-///
-/// <h1> Example </h1>
-///
-/// <h3> Sample Code: </h3>
-///
-/// ````
-/// use vanity_key::generate_vanity_key;
-///
-/// generate_vanity_key("A");
-/// ````
-///
-/// <h3> Possible Output: </h3>
-/// ````
-/// SEARCHING INITIATED
-///
-/// SUCCESS!
-/// Public Key: "GANKWRSNEREXR3TOVBCJDZG5V4JN3JICK7VP7NUGTCKRX2PDMOKC5REA"
-/// Secret Key: "SBTYFPJ6MZ4BXXXWP5N6RYPNZPLWKI4EJNPGJRBLHOIISZKPM5AOEGQT"
-/// ````
-pub fn generate_vanity_key(word: &str) -> (String, String) {
-    let start = 56 - word.len();
+impl<T> AddressGenerator<T>
+where
+    T: Rng + CryptoRng,
+{
+    pub fn new(rng: T) -> AddressGenerator<T> {
+        AddressGenerator { rng }
+    }
 
-    // Create cryptographically secure pseudorandom number generator
-    let mut rng = OsRng::new().unwrap();
+    fn generate_random_key(&mut self) -> (String, String) {
+        // Generate ED25519 key pair
+        let keypair: Keypair = Keypair::generate(&mut self.rng);
 
-    loop {
-        let (public_key, private_key) = generate_random_key(&mut rng);
-        let three_letter = &public_key[start..];
-        if three_letter == word {
-            return (public_key.clone(), private_key.clone());
-        }
+        // ************** Encode the public key ***************** //
+        const VERSION_BYTE_ACCOUNT_ID: u8 = 6 << 3;
+        let mut bytes_public = vec![VERSION_BYTE_ACCOUNT_ID];
+        // Combine the byte version and the ED25519 raw public key bytes array
+        &bytes_public.extend_from_slice(&keypair.public.to_bytes());
+        // Calculate checksum
+        let checksum_public = State::<XMODEM>::calculate(&bytes_public);
+        // Create a buffer to combine byte version : ED25519 raw key : checksum
+        let mut bytes_buffer_public = BytesMut::with_capacity(1024);
+        bytes_buffer_public.put(&bytes_public);
+        bytes_buffer_public.put_u16_le(checksum_public);
+        // Base 32 encode the public key
+        let public_key = encode(RFC4648 { padding: false }, &bytes_buffer_public);
+
+        // ************** Encode the private key ***************** //
+        const VERSION_BYTE_SEED: u8 = 18 << 3;
+        let mut bytes_private = vec![VERSION_BYTE_SEED];
+        // Combine the byte version and the ED25519 raw private key bytes array
+        &bytes_private.extend_from_slice(&keypair.secret.to_bytes());
+        // Calculate checksum
+        let check_sum_private = State::<XMODEM>::calculate(&bytes_private);
+        // Create a buffer to combine byte version : ED25519 raw key : checksum
+        let mut bytes_buffer_private = BytesMut::with_capacity(1024);
+        bytes_buffer_private.put(&bytes_private);
+        bytes_buffer_private.put_u16_le(check_sum_private);
+        // Base 32 encode the private key
+        let private_key = encode(RFC4648 { padding: false }, &bytes_buffer_private);
+
+        (public_key, private_key)
+    }
+}
+
+impl Default for AddressGenerator<OsRng> {
+    fn default() -> Self {
+        let rng = OsRng::new().unwrap();
+
+        AddressGenerator { rng }
+    }
+}
+
+impl<T> Iterator for AddressGenerator<T>
+where
+    T: Rng + CryptoRng,
+{
+    type Item = (String, String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(self.generate_random_key())
     }
 }


### PR DESCRIPTION
Addresses #2 

I am not sure, where prefix in public key should start from. We definitely can skip first letter, because it's always "G". However, it seems that the second letter can be only from some narrow set, but I didn't prove it yet :) So maybe we should allow the second letter to be the part of the prefix to, but validate it.

What do you think about it?